### PR TITLE
Add types for Jest and Enzyme for testing

### DIFF
--- a/projects/project2/package.json
+++ b/projects/project2/package.json
@@ -1,5 +1,7 @@
 {
     "dependencies": {
+        "@types/enzyme": "*",
+        "@types/jest": "*",
         "async": "*",
         "axios": "*",
         "classnames": "*",
@@ -42,6 +44,7 @@
         "file-saver": "*",
         "flow-bin": "*",
         "@material-ui/core": "*",
+        "@material-ui/icons": "*",
         "prop-types": "*",
         "react": "*",
         "react-animations": "*",


### PR DESCRIPTION
Add @types for enzyme and jest to support JetBrains IDEs (PyCharm/WebStorm) unit testing libraries.